### PR TITLE
SA-77: Add role sync settings

### DIFF
--- a/cognito_sso.info
+++ b/cognito_sso.info
@@ -1,0 +1,10 @@
+name = Cognito SSO
+description = Single Sign On extended features for Drupal 7 websites.
+core = 7.x
+package = "OAuth2"
+version = 7.x-1.0
+dependencies[] = entity
+dependencies[] = ctools
+dependencies[] = drupal_sso
+dependencies[] = openid_connect
+dependencies[] = xautoload:xautoload

--- a/cognito_sso.module
+++ b/cognito_sso.module
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Single Sign On extended features for Drupal 7 websites.
+ */
+
+/**
+ * Implements hook_form_alter().
+ */
+function cognito_sso_form_alter(array &$form, array &$form_state, $form_id) {
+
+  // Adding a Role sync field to openid_connect config form.
+  if ($form_id == 'openid_connect_admin_form') {
+    $form['user_role_sync'] = array(
+      '#title' => t('Role sync'),
+      '#type' => 'fieldset',
+    );
+
+    $form['user_role_sync']['openid_connect_enable_role_sync'] = array(
+      '#title' => t('Enable Role sync'),
+      '#description' => t('Enabling this will send the user role data to the IDP.'),
+      '#type' => 'checkbox',
+      '#default_value' => variable_get('openid_connect_enable_role_sync', TRUE),
+    );
+
+    // Additional submit handler for openid connect value.
+    $form['actions']['submit']['#submit'][] = 'cognito_sso_openid_connect_admin_form_submit';
+  }
+}
+
+/**
+ * Additional submit handler for openid connect value.
+ */
+function cognito_sso_openid_connect_admin_form_submit(&$form, &$form_state) {
+  if (isset($form_state['values']['user_role_sync']['openid_connect_enable_role_sync'])) {
+    variable_set('openid_connect_enable_role_sync', $form_state['values']['user_role_sync']['openid_connect_enable_role_sync']);
+  }
+}


### PR DESCRIPTION
## Overview
Add role sync field to the openid_connect config form.

## Before
The role sync field was not added to the openid_connect config form.
<img width="1159" alt="role_sync_before" src="https://user-images.githubusercontent.com/126798502/233536482-162ec8e5-bcb4-4b15-9119-5120298cce0a.png">

## After
The role sync field is added to the openid_connect config form.
<img width="653" alt="role_sync_after" src="https://user-images.githubusercontent.com/126798502/233536339-717e3ee2-72ce-4082-a8ec-62c775ec2458.png">

## Technical Details
Added form alter hook and custom submit handler to add a Role sync field and save its value.