### PR TITLE
FOSFAB-137: Add the required form field and settings to display form

### DIFF
--- a/CRM/Activitynotificationrestrictions/Upgrader/Base.php
+++ b/CRM/Activitynotificationrestrictions/Upgrader/Base.php
@@ -48,7 +48,7 @@ class CRM_Activitynotificationrestrictions_Upgrader_Base {
   public static function instance() {
     if (!self::$instance) {
       self::$instance = new CRM_Activitynotificationrestrictions_Upgrader(
-        'io.compuco.automateddirectdebit',
+        'io.compuco.activitynotificationrestrictions',
         E::path()
       );
     }

--- a/activitynotificationrestrictions.php
+++ b/activitynotificationrestrictions.php
@@ -78,3 +78,16 @@ function activitynotificationrestrictions_civicrm_upgrade($op, CRM_Queue_Queue $
 function activitynotificationrestrictions_civicrm_entityTypes(&$entityTypes) {
   _activitynotificationrestrictions_civix_civicrm_entityTypes($entityTypes);
 }
+
+/**
+ * Implements hook_civicrm_buildForm().
+ */
+function activitynotificationrestrictions_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Admin_Form_Preferences_Display') {
+    // Adds the HTML markup to the form.
+    $templatePath = realpath(dirname(__FILE__) . "/templates");
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$templatePath}/Settings.tpl",
+    ]);
+  }
+}

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -3,6 +3,6 @@
   <description>CiviCRM Coder Ruleset</description>
   <rule ref="bin/civicrm/coder/coder_sniffer/Drupal">
     <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
-    <exclude-pattern>automateddirectdebit.civix.php</exclude-pattern>
+    <exclude-pattern>activitynotificationrestrictions.civix.php</exclude-pattern>
   </rule>
 </ruleset>

--- a/settings/Restriction.setting.php
+++ b/settings/Restriction.setting.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+  'restrict_email_recipient_groups' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'restrict_email_recipient_groups',
+    'type' => 'Array',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => [],
+    'title' => ts('Restrict email recipients to groups'),
+    'description' => ts('Limit which contacts will receive a CiviCRM activity notification email when an activity is assigned to them. You can select any group or smart group. Leave blank for no restriction. Note that you may still assign an activity to a contact who is not in the group, but they will not receive an email.'),
+    'html_type' => 'select',
+    'html_attributes' => [
+      'multiple' => 1,
+      'class' => 'huge crm-select2',
+    ],
+    'pseudoconstant' => [
+      'table' => 'civicrm_group',
+      'keyColumn' => 'id',
+      'labelColumn' => 'title',
+    ],
+    'quick_form_type' => 'Select',
+    'settings_pages' => ['display' => ['weight' => -1]],
+  ],
+  'restrict_email_recipient_website_users' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'restrict_email_recipient_website_users',
+    'type' => 'Boolean',
+    'html_type' => 'checkbox',
+    'default' => TRUE,
+    'title' => ts('Restrict email recipients to Website Users'),
+    'description' => ts('Limit which contacts will receive a CiviCRM activity notification email to only be those who have a CMS user when an activity is assigned to them. Note that you may still assign an activity to a contact who does not have a CMS user, but they will not receive an email.'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'settings_pages' => ['display' => ['weight' => -1]],
+  ],
+];

--- a/templates/Settings.tpl
+++ b/templates/Settings.tpl
@@ -1,0 +1,47 @@
+<script type="text/javascript">
+  {literal}
+  (function($) {
+
+    $(function() {
+      moveFields();
+    });
+
+    /**
+     * Re-organise fields
+     */
+    function moveFields() {
+      $('.crm-preferences-display-form-activity_assignee_group_restriction').insertAfter($('.crm-preferences-display-form-activity_types').has('td.description'));
+      $('#group-email-restriction-field-description').insertAfter($('.crm-preferences-display-form-activity_assignee_group_restriction'));
+      $('.crm-preferences-display-form-activity_assignee_cms_user_restriction').insertBefore($('.crm-preferences-display-form-block-activity_assignee_notification_ics'));
+      $('#cms-user-email-restriction-field-description').insertAfter($('.crm-preferences-display-form-activity_assignee_cms_user_restriction'));
+    }
+
+  })(CRM.$);
+  {/literal}
+</script>
+<table>
+  <tr class="crm-preferences-display-form-activity_assignee_group_restriction">
+    <td class="label">
+      <label for="restrict_email_recipient_groups">{ts}Restrict email recipients to groups{/ts}</label>
+    </td>
+    <td>{$form.restrict_email_recipient_groups.html}</td>
+  </tr>
+  <tr id="group-email-restriction-field-description" class="crm-preferences-display-form-block-description">
+    <td>&nbsp;</td>
+    <td class="description">
+      {ts}Limit which contacts will receive a CiviCRM activity notification email when an activity is assigned to them. You can select any group or smart group. Leave blank for no restriction. Note that you may still assign an activity to a contact who is not in the group, but they will not receive an email.{/ts}
+    </td>
+  </tr>
+  <tr class="crm-preferences-display-form-activity_assignee_cms_user_restriction">
+    <td class="label"></td>
+    <td>
+      {$form.restrict_email_recipient_website_users.html}
+    </td>
+  </tr>
+  <tr id="cms-user-email-restriction-field-description" class="crm-preferences-display-form-block-description">
+    <td>&nbsp;</td>
+    <td class="description">
+      {ts}Limit which contacts will receive a CiviCRM activity notification email to only be those who have a CMS user when an activity is assigned to them. Note that you may still assign an activity to a contact who does not have a CMS user, but they will not receive an email.{/ts}
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Overview
This PR aims to add the required form field and settings to display preferences form

## Before
![image](https://github.com/compucorp/io.compuco.activitynotificationrestrictions/assets/102582516/8101c53d-ae6c-43da-91c4-321603389e21)


## After
![image](https://github.com/compucorp/io.compuco.activitynotificationrestrictions/assets/102582516/76dffe09-8b18-410b-99eb-f231be0b6171)


![image](https://github.com/compucorp/io.compuco.activitynotificationrestrictions/assets/102582516/c5caef12-669a-4a1c-ba80-f01b04225bcb)

## Technical Details
1. Added the settings for the select field and boolean field to the display preferences form.
2. Added a custom template in the hook build form to render the newly added fields as part of this form.
3. Fixed some skeletal issues.